### PR TITLE
fix version report: replace git dirty with ci platform due to bug in crate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
             runner: warp-ubuntu-latest-x64-16x
 
     steps:
-      - uses: WarpBuilds/rust-cache@v2
+      # - uses: WarpBuilds/rust-cache@v2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,8 +65,6 @@ jobs:
             runner: warp-ubuntu-latest-x64-16x
 
     steps:
-      - uses: WarpBuilds/rust-cache@v2
-
       - name: Install dependencies
         run: |
           apt-get update
@@ -84,13 +82,6 @@ jobs:
 
       - name: Prepare filename
         run: echo "OUTPUT_FILENAME=rbuilder-${VERSION}-${{ matrix.configs.target }}" >> $GITHUB_ENV
-
-      - name: Debug dirty
-        run: |
-          git config --global --add safe.directory "$(pwd)"
-          echo status && git status --porcelain
-          echo diff && git diff --cached --name-status
-          echo ls-files && git ls-files --others --exclude-standard
 
       - name: Build binary
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,17 +85,24 @@ jobs:
       - name: Prepare filename
         run: echo "OUTPUT_FILENAME=rbuilder-${VERSION}-${{ matrix.configs.target }}" >> $GITHUB_ENV
 
-      - name: Build binary
+      - name: Debug dirty
         run: |
           git config --global --add safe.directory "$(pwd)"
-          . $HOME/.cargo/env
-          cargo build --release --target ${{ matrix.configs.target }}
+          echo status && git status --porcelain
+          echo diff && git diff --cached --name-status
+          echo ls-files && git ls-files --others --exclude-standard
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.OUTPUT_FILENAME }}
-          path: target/${{ matrix.configs.target }}/release/rbuilder
+      # - name: Build binary
+      #   run: |
+      #     git config --global --add safe.directory "$(pwd)"
+      #     . $HOME/.cargo/env
+      #     cargo build --release --target ${{ matrix.configs.target }}
+
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ env.OUTPUT_FILENAME }}
+      #     path: target/${{ matrix.configs.target }}/release/rbuilder
 
   draft-release:
     name: Draft release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,7 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           . $HOME/.cargo/env
           cargo build --release --target ${{ matrix.configs.target }}
+          ./target/${{ matrix.configs.target }}/release/rbuilder version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
             runner: warp-ubuntu-latest-x64-16x
 
     steps:
-      # - uses: WarpBuilds/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@v2
 
       - name: Install dependencies
         run: |
@@ -92,17 +92,17 @@ jobs:
           echo diff && git diff --cached --name-status
           echo ls-files && git ls-files --others --exclude-standard
 
-      # - name: Build binary
-      #   run: |
-      #     git config --global --add safe.directory "$(pwd)"
-      #     . $HOME/.cargo/env
-      #     cargo build --release --target ${{ matrix.configs.target }}
+      - name: Build binary
+        run: |
+          git config --global --add safe.directory "$(pwd)"
+          . $HOME/.cargo/env
+          cargo build --release --target ${{ matrix.configs.target }}
 
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ env.OUTPUT_FILENAME }}
-      #     path: target/${{ matrix.configs.target }}/release/rbuilder
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.OUTPUT_FILENAME }}
+          path: target/${{ matrix.configs.target }}/release/rbuilder
 
   draft-release:
     name: Draft release

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -5,8 +5,8 @@ mod internal {
 }
 
 use internal::{
-    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_DIRTY, GIT_HEAD_REF, PROFILE,
-    RUSTC_VERSION, CI_PLATFORM,
+    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_HEAD_REF, PROFILE,
+    RUSTC_VERSION, CI_PLATFORM, // GIT_DIRTY,
 };
 use rbuilder::utils::build_info::Version;
 
@@ -14,7 +14,7 @@ pub fn print_version_info() {
     // println!("dirty:      {}", GIT_DIRTY.unwrap_or_default());
     println!("commit:         {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
     println!("branch:         {}", GIT_HEAD_REF.unwrap_or_default());
-    println!("build_platform: {}", CI_PLATFORM);
+    println!("build_platform: {:?}", CI_PLATFORM);
     println!("build_time:     {}", BUILT_TIME_UTC);
     println!("features:       {:?}", FEATURES);
     println!("profile:        {}", PROFILE);

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -6,18 +6,19 @@ mod internal {
 
 use internal::{
     BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_DIRTY, GIT_HEAD_REF, PROFILE,
-    RUSTC_VERSION,
+    RUSTC_VERSION, CI_PLATFORM,
 };
 use rbuilder::utils::build_info::Version;
 
 pub fn print_version_info() {
-    println!("commit:     {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
-    println!("dirty:      {}", GIT_DIRTY.unwrap_or_default());
-    println!("branch:     {}", GIT_HEAD_REF.unwrap_or_default());
-    println!("build_time: {}", BUILT_TIME_UTC);
-    println!("rustc:      {}", RUSTC_VERSION);
-    println!("features:   {:?}", FEATURES);
-    println!("profile:    {}", PROFILE);
+    // println!("dirty:      {}", GIT_DIRTY.unwrap_or_default());
+    println!("commit:         {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
+    println!("branch:         {}", GIT_HEAD_REF.unwrap_or_default());
+    println!("build_platform: {}", CI_PLATFORM);
+    println!("build_time:     {}", BUILT_TIME_UTC);
+    println!("features:       {:?}", FEATURES);
+    println!("profile:        {}", PROFILE);
+    println!("rustc:          {}", RUSTC_VERSION);
 }
 
 pub fn rbuilder_version() -> Version {
@@ -26,11 +27,11 @@ pub fn rbuilder_version() -> Version {
         if let Some(hash) = GIT_COMMIT_HASH_SHORT {
             commit.push_str(hash);
         }
-        if let Some(dirty) = GIT_DIRTY {
-            if dirty {
-                commit.push_str("-dirty");
-            }
-        }
+        // if let Some(dirty) = GIT_DIRTY {
+        //     if dirty {
+        //         commit.push_str("-dirty");
+        //     }
+        // }
         if commit.is_empty() {
             commit.push_str("unknown");
         }

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -11,7 +11,10 @@ use internal::{
 use rbuilder::utils::build_info::Version;
 
 pub fn print_version_info() {
-    println!("commit:         {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
+    println!(
+        "commit:         {}",
+        GIT_COMMIT_HASH_SHORT.unwrap_or_default()
+    );
     println!("branch:         {}", GIT_HEAD_REF.unwrap_or_default());
     println!("build_platform: {:?}", CI_PLATFORM.unwrap_or_default());
     println!("build_time:     {}", BUILT_TIME_UTC);

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -5,16 +5,15 @@ mod internal {
 }
 
 use internal::{
-    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_HEAD_REF, PROFILE,
-    RUSTC_VERSION, CI_PLATFORM, // GIT_DIRTY,
+    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_HEAD_REF, PROFILE, RUSTC_VERSION,
+    CI_PLATFORM,
 };
 use rbuilder::utils::build_info::Version;
 
 pub fn print_version_info() {
-    // println!("dirty:      {}", GIT_DIRTY.unwrap_or_default());
     println!("commit:         {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
     println!("branch:         {}", GIT_HEAD_REF.unwrap_or_default());
-    println!("build_platform: {:?}", CI_PLATFORM);
+    println!("build_platform: {:?}", CI_PLATFORM.unwrap_or_default());
     println!("build_time:     {}", BUILT_TIME_UTC);
     println!("features:       {:?}", FEATURES);
     println!("profile:        {}", PROFILE);
@@ -27,11 +26,6 @@ pub fn rbuilder_version() -> Version {
         if let Some(hash) = GIT_COMMIT_HASH_SHORT {
             commit.push_str(hash);
         }
-        // if let Some(dirty) = GIT_DIRTY {
-        //     if dirty {
-        //         commit.push_str("-dirty");
-        //     }
-        // }
         if commit.is_empty() {
             commit.push_str("unknown");
         }

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -5,8 +5,8 @@ mod internal {
 }
 
 use internal::{
-    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_HEAD_REF, PROFILE, RUSTC_VERSION,
-    CI_PLATFORM,
+    BUILT_TIME_UTC, CI_PLATFORM, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_HEAD_REF, PROFILE,
+    RUSTC_VERSION,
 };
 use rbuilder::utils::build_info::Version;
 


### PR DESCRIPTION
- removes the warpcache. it's not doing anything right now and upstream needs updating
- replaces the report of `dirty` from the `version` flag with `build_platform` because the `built` crate has [a bug](https://github.com/lukaslueg/built/issues/66) with `dirty` always reporting `true`

output now [looks like this](https://github.com/flashbots/rbuilder-operator/actions/runs/11806471344/job/32891207294#step:7:1826):
```sh
commit:         8bbfeb0
branch:         refs/heads/dirty-builds
build_platform: "GitHub Actions"
build_time:     Tue, 12 Nov 2024 22:07:06 +0000
features:       []
profile:        release
rustc:          rustc 1.82.0 (f6e511eec 2024-10-15)
```