### PR TITLE
move websocket feed to async and add read timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -928,7 +928,7 @@ dependencies = [
  "rustls 0.23.21",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.1",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "ws_stream_wasm",
 ]
@@ -3200,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3820,6 +3820,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5523,7 +5535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6456,7 +6468,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -7264,7 +7276,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -7672,7 +7684,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7716,6 +7728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7736,6 +7759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7751,6 +7784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -7975,6 +8017,7 @@ dependencies = [
  "clickhouse",
  "crossbeam-queue",
  "ctor",
+ "exponential-backoff",
  "eyre",
  "flume",
  "futures",
@@ -8003,13 +8046,13 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "toml 0.8.19",
  "tonic",
  "tonic-build",
  "tower 0.4.13",
  "tracing",
- "tungstenite 0.23.0",
  "url",
  "uuid",
 ]
@@ -10977,7 +11020,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12482,7 +12525,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12773,9 +12816,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -12783,7 +12826,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
- "tungstenite 0.26.1",
+ "tungstenite 0.26.2",
  "webpki-roots 0.26.7",
 ]
 
@@ -13150,17 +13193,16 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.2.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "rustls 0.23.21",
  "rustls-pki-types",
  "sha1",
@@ -13510,6 +13552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13698,7 +13749,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14021,6 +14072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14112,7 +14172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -14120,6 +14189,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ jsonrpsee = { version = "0.20.3", features = ["full"] }
 tracing = "0.1.37"
 time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
 thiserror = "1.0.64"
-tungstenite = "0.23.0"
 ahash = "0.8.6"
 itertools = "0.11.0"
 rand = "0.8.5"
@@ -62,6 +61,8 @@ metrics_macros =  { git = "https://github.com/flashbots/rbuilder.git", rev = "43
 
 #rbuilder = {path="./../rbuilder/crates/rbuilder"}
 rbuilder = { git = "https://github.com/flashbots/rbuilder.git", rev = "43d7a9d5a95f44d188b5e8c8eba3053fd08fc8ae"}
+tokio-tungstenite = "0.26.2"
+exponential-backoff = "1.2.0"
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/src/best_bid_ws.rs
+++ b/src/best_bid_ws.rs
@@ -2,29 +2,33 @@
 //!
 //! This module uses websocket connection to get best bid value from the relays.
 //! The best bid for the current block-slot is stored in the `BestBidCell` and can be read at any time.
-use alloy_primitives::{utils::format_ether, U256};
-use rbuilder::{
-    live_builder::block_output::bid_value_source::interfaces::{BidValueObs, BidValueSource},
-    utils::reconnect::{run_loop_with_reconnect, RunCommand},
-};
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use alloy_primitives::utils::format_ether;
+use rbuilder::live_builder::block_output::bid_value_source::interfaces::{BidValueObs, BidValueSource};
 use serde::Deserialize;
-use std::{
-    ops::DerefMut,
-    sync::{Arc, Mutex},
-};
+use crate::reconnect::{run_async_loop_with_reconnect, RunCommand};
+use tokio::net::TcpStream;
+use tokio_stream::StreamExt;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::tungstenite::Error;
+use tokio_tungstenite::{connect_async_with_config, tungstenite::protocol::Message};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, trace, warn};
-use tungstenite::{
-    client::{connect_with_config, IntoClientRequest},
-    http::Request,
-    Message,
-};
+use alloy_primitives::U256;
 
 use crate::metrics::inc_non_0_competition_bids;
 
+type Connection = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
 const MAX_IO_ERRORS: usize = 5;
 
-const WS_CONNECT_MAX_REDIRECTS: u8 = 3;
+// time that we wait for a new value before reconnecting
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -35,11 +39,12 @@ pub struct BestBidValue {
 }
 
 #[derive(Debug)]
-struct Subscription {
+pub struct Subscription {
     pub block_number: u64,
     pub slot_number: u64,
     pub obs: Arc<dyn BidValueObs>,
 }
+
 
 /// Struct that connects to a websocket feed with best bids from the competition.
 /// Allows to subscribe so listen for changes on a particular slot.
@@ -51,8 +56,8 @@ struct Subscription {
 /// - call unsubscribe(sub)
 #[derive(Debug)]
 pub struct BestBidWSConnector {
-    connection_request: Request<()>,
-    subscriptions: Mutex<Vec<Subscription>>,
+    connection_request: Request,
+    subscriptions: Arc<Mutex<Vec<Subscription>>>,
 }
 
 impl BestBidWSConnector {
@@ -68,99 +73,122 @@ impl BestBidWSConnector {
         })
     }
 
-    pub fn run_ws_stream(
+    pub async fn run_ws_stream(
         &self,
         // We must try_send on every non 0 bid or the process will be killed
         watch_dog_sender: flume::Sender<()>,
         cancellation_token: CancellationToken,
     ) {
-        run_loop_with_reconnect(
+	run_async_loop_with_reconnect(
             "ws_top_bid_connection",
-            || {
-                connect_with_config(
-                    self.connection_request.clone(),
-                    None,
-                    WS_CONNECT_MAX_REDIRECTS,
-                )
-                .map(|(c, _)| c)
-            },
-            |mut conn| -> RunCommand {
-                let mut io_error_count = 0;
-                loop {
-                    if cancellation_token.is_cancelled() {
-                        break;
-                    }
-                    if io_error_count >= MAX_IO_ERRORS {
-                        warn!("Too many read errors, reconnecting");
-                        return RunCommand::Reconnect;
-                    }
-
-                    let res = conn.read();
-                    let message = match res {
-                        Ok(message) => message,
-                        Err(err) => {
-                            warn!(?err, "Error reading WS stream");
-                            io_error_count += 1;
-                            continue;
-                        }
-                    };
-                    let data = match message {
-                        Message::Text(msg) => msg.into_bytes(),
-                        Message::Binary(msg) => msg,
-                        Message::Ping(data) => {
-                            trace!("Received ping");
-                            match conn.write(Message::Pong(data)) {
-                                Ok(()) => {}
-                                Err(err) => {
-                                    warn!(?err, "Error writing pong");
-                                    io_error_count += 1;
-                                }
-                            }
-                            continue;
-                        }
-                        Message::Pong(_) | Message::Frame(_) => {
-                            continue;
-                        }
-                        Message::Close(_) => {
-                            warn!("Connection closed, reconnecting");
-                            return RunCommand::Reconnect;
-                        }
-                    };
-
-                    let bid_value: BestBidValue = match serde_json::from_slice(&data) {
-                        Ok(value) => value,
-                        Err(err) => {
-                            error!(?err, "Failed to parse best bid value");
-                            continue;
-                        }
-                    };
-
-                    if !bid_value.block_top_bid.is_zero() {
-                        inc_non_0_competition_bids();
-                        let _ = watch_dog_sender.try_send(());
-                    }
-
-                    trace!(
-                        block = bid_value.block_number,
-                        slot = bid_value.slot_number,
-                        value = format_ether(bid_value.block_top_bid),
-                        "Updated best bid value"
-                    );
-
-                    for sub in self.subscriptions.lock().unwrap().deref_mut() {
-                        if sub.block_number == bid_value.block_number
-                            && sub.slot_number == bid_value.slot_number
-                        {
-                            sub.obs.update_new_bid(bid_value.block_top_bid);
-                        }
-                    }
-                }
-                RunCommand::Finish
-            },
+            || connect(self.connection_request.clone()),
+            |conn| run_command(conn, cancellation_token.clone(), watch_dog_sender.clone(), self.subscriptions.clone()),
+            None,
             cancellation_token.clone(),
-        );
+    )
+	    .await;
     }
 }
+
+async fn connect<R>(request: R) -> Result<Connection, Error>
+where
+    R: IntoClientRequest + Unpin,
+{
+    connect_async_with_config(
+        request, None, true, // TODO: naggle, decide
+    )
+    .await
+    .map(|(c, _)| c)
+}
+
+async fn run_command(
+    mut conn: Connection,
+    cancellation_token: CancellationToken,
+    watch_dog_sender: flume::Sender<()>,
+    subscriptions: Arc<Mutex<Vec<Subscription>>>,
+) -> RunCommand {
+    let mut io_error_count = 0;
+    loop {
+        if cancellation_token.is_cancelled() {
+            break;
+        }
+        if io_error_count >= MAX_IO_ERRORS {
+            warn!("Too many read errors, reconnecting");
+            return RunCommand::Reconnect;
+        }
+
+	let next_message = tokio::time::timeout(READ_TIMEOUT, conn.next());
+        let res = match next_message.await {
+	    Ok(res) => res,
+	    Err(err) => {
+		warn!(?err, "Timeout error");
+                return RunCommand::Reconnect;
+	    }
+	};
+        let message = match res {
+            Some(Ok(message)) => message,
+            Some(Err(err)) => {
+                warn!(?err, "Error reading WS stream");
+                io_error_count += 1;
+                continue;
+            },
+	    None => {
+		warn!("Connection read stream is closed, reconnecting");
+                return RunCommand::Reconnect;
+	    },
+        };
+        let data = match &message {
+            Message::Text(msg) => msg.as_bytes(),
+            Message::Binary(msg) => msg.as_ref(),
+            Message::Ping(_) => {
+                error!(ws_message = "ping", "Received unexpected message");
+                continue;
+            }
+            Message::Pong(_) => {
+                error!(ws_message = "pong", "Received unexpected message");
+                continue;
+            }
+            Message::Frame(_) => {
+                error!(ws_message = "frame", "Received unexpected message");
+                continue;
+            }
+            Message::Close(_) => {
+                warn!("Connection closed, reconnecting");
+                return RunCommand::Reconnect;
+            }
+        };
+
+        let bid_value: BestBidValue = match serde_json::from_slice(data) {
+            Ok(value) => value,
+            Err(err) => {
+                error!(?err, "Failed to parse best bid value");
+                continue;
+            }
+        };
+
+        if !bid_value.block_top_bid.is_zero() {
+            inc_non_0_competition_bids();
+            let _ = watch_dog_sender.try_send(());
+        }
+
+        trace!(
+            block = bid_value.block_number,
+            slot = bid_value.slot_number,
+            value = format_ether(bid_value.block_top_bid),
+            "Updated best bid value"
+        );
+
+        for sub in subscriptions.lock().unwrap().deref_mut() {
+            if sub.block_number == bid_value.block_number
+                && sub.slot_number == bid_value.slot_number
+            {
+                sub.obs.update_new_bid(bid_value.block_top_bid);
+            }
+        }
+    }
+    RunCommand::Finish
+}
+
 
 impl BidValueSource for BestBidWSConnector {
     fn subscribe(&self, block_number: u64, slot_number: u64, obs: Arc<dyn BidValueObs>) {
@@ -178,3 +206,5 @@ impl BidValueSource for BestBidWSConnector {
             .retain(|s| !Arc::ptr_eq(&s.obs, &obs));
     }
 }
+
+

--- a/src/flashbots_config.rs
+++ b/src/flashbots_config.rs
@@ -411,9 +411,9 @@ impl FlashbotsConfig {
                     eyre::bail!("Watchdog not enabled. Needed for bid source");
                 }
             };
-            std::thread::spawn(move || {
-                connector_clone.run_ws_stream(watchdog_sender, cancellation_token);
-            });
+            tokio::spawn(async move {
+		connector_clone.run_ws_stream(watchdog_sender, cancellation_token).await
+	    });
             Ok(connector)
         } else {
             error!("No BidValueSource configured, using NullBidValueSource");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod flashbots_config;
 pub mod flashbots_signer;
 pub mod metrics;
 pub mod signed_http_client;
+pub mod reconnect;
 mod true_block_value_push;

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -1,0 +1,66 @@
+use exponential_backoff::Backoff;
+use std::{future::Future, time::Duration};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, info_span, warn, Instrument};
+
+
+#[derive(Debug)]
+pub enum RunCommand {
+    Reconnect,
+    Finish,
+}
+
+fn default_backoff() -> Backoff {
+    Backoff::new(u32::MAX, Duration::from_secs(1), Duration::from_secs(12))
+}
+
+pub async fn run_async_loop_with_reconnect<
+    Connection,
+    ConnectErr: std::error::Error,
+    ConnectFut: Future<Output = Result<Connection, ConnectErr>>,
+    RunFut: Future<Output = RunCommand>,
+    Connect: Fn() -> ConnectFut,
+    Run: Fn(Connection) -> RunFut,
+>(
+    context: &str,
+    connect: Connect,
+    run: Run,
+    backoff: Option<Backoff>,
+    cancellation_token: CancellationToken,
+) {
+    let span = info_span!("connect_loop_context", context);
+
+    'reconnect: loop {
+        if cancellation_token.is_cancelled() {
+            break 'reconnect;
+        }
+        let backoff = backoff.clone().unwrap_or_else(|| default_backoff());
+        let mut backoff_iter = backoff.iter();
+
+        let connection = 'backoff: loop {
+            let timeout = if let Some(timeout) = backoff_iter.next() {
+                timeout
+            } else {
+                warn!(parent: &span, "Backoff for connection reached max retries");
+                break 'reconnect;
+            };
+
+            match connect().instrument(span.clone()).await {
+                Ok(conn) => {
+                    debug!(parent: &span, "Established connection");
+                    break 'backoff conn;
+                }
+                Err(err) => {
+                    error!(parent: &span, ?err, "Failed to establish connection");
+                    tokio::time::sleep(timeout).await;
+                }
+            }
+        };
+
+        match run(connection).instrument(span.clone()).await {
+            RunCommand::Reconnect => continue 'reconnect,
+            RunCommand::Finish => break 'reconnect,
+        }
+    }
+    info!("Exiting connect loop");
+}


### PR DESCRIPTION
This fix prevents processes from hanging indefinitely while waiting for reads on dead connections.
Previously, these processes would remain stuck until terminated by the watchdog.